### PR TITLE
Typo in Makefile and Linux include to heed warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# build artifacts
+/WakeOnLAN

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
-WakeOnLAN: WakeOnLan.c
-	gcc -o WakeOnLAN WakeOnLAN.c
+WakeOnLAN: WakeOnLAN.c
+	$(CC) -o $@ $<

--- a/WakeOnLAN.c
+++ b/WakeOnLAN.c
@@ -33,6 +33,7 @@
 	#include <sys/types.h>
 	#include <sys/socket.h>
 	#include <netinet/in.h>
+	#include <arpa/inet.h>
 	#include <netdb.h>
 #endif
 #ifdef _WIN32


### PR DESCRIPTION
I've got this thing working on my Ubuntu machine to wake up an old laptop over LAN.  Thanks for writing this tool, it's handy.

I saw the `Makefile` in the repo, but it listed `WakeOnLan.c` as a dependency instead of `WakeOnLAN.c` (capital `LAN`), so I fixed that, and while I was there I used the special `make` variables `$@` and `$<` to avoid restating the target and its dependency.

Then when I compiled the code, GCC warned that `inet_addr` was implicitly defined, so I included the header file from OpenGroup's documentation on `inet_addr`. You had already included it for Darwin.

I also added a `.gitignore` file to exclude the built binary.