### PR TITLE
Fix warning + Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,9 @@
 WakeOnLAN: WakeOnLAN.c
 	$(CC) -o $@ $<
+
+clean:
+	rm WakeOnLAN
+
+all: WakeOnLAN
+
+.PHONY: WakeOnLan all

--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ For Windows you can compile the source using MinGW
 gcc WakeOnLAN.c -o WakeOnLAN.exe -lwsock32
 ```
 
+### Makefile
+GNU make can be used in order to compile the sources on Linux/Mac:
+```bash
+make
+```
+to clean everything:
+```bash
+make clean
+```
 ___
 
 ### Feedback

--- a/WakeOnLAN.c
+++ b/WakeOnLAN.c
@@ -111,7 +111,7 @@ int main(int argc, const char* argv[]){
 	}
 
 	// Print address
-	printf("Packet will be sent to %02hhx:%02x:%02x:%02x:%02x:%02x\n", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+	printf("Packet will be sent to %02x:%02x:%02x:%02x:%02x:%02x\n", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
 
 	// Check if a broadcast address was given too
 	if(argc > 2){


### PR DESCRIPTION
This MR fixes this warning I encountered when compiling:
```bash
WakeOnLAN.c:114:69: warning: format specifies type 'unsigned char' but the argument has type 'unsigned int' [-Wformat]
        printf("Packet will be sent to %02hhx:%02x:%02x:%02x:%02x:%02x\n", mac[0], mac[1], mac[2], mac[3], mac[4...
                                       ~~~~~~                              ^~~~~~
                                       %02x
1 warning generated.
```
Other minor changes are included.

Best regards