### PR TITLE
Fix Apple compile error

### DIFF
--- a/WakeOnLAN.c
+++ b/WakeOnLAN.c
@@ -57,6 +57,12 @@
 #include <string.h>
 #include <ctype.h>
 
+#ifdef __APPLE__
+	#define SO_BIND_OPT_NAME IP_BOUND_IF
+#elif defined(__linux)
+	#define SO_BIND_OPT_NAME SO_BINDTODEVICE
+#endif
+
 // Create Magic Packet
 void createMagicPacket(unsigned char packet[], unsigned int macAddress[]){
 	int i;
@@ -155,7 +161,7 @@ int main(int argc, const char* argv[]){
 			struct ifreq ifr;
 			memset(&ifr, 0, sizeof(ifr));
 			snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "%s", argv[3]);
-			if (setsockopt(udpSocket, SOL_SOCKET, SO_BINDTODEVICE, (void *)&ifr, sizeof(ifr)) < 0) {
+			if (setsockopt(udpSocket, SOL_SOCKET, SO_BIND_OPT_NAME, (void *)&ifr, sizeof(ifr)) < 0) {
 				printf("Failed to bind interface: '%s'.\n", strerror(errno));
 				exit(EXIT_FAILURE);
 			}


### PR DESCRIPTION
Here is a fix for the error I got when compiling on MAC OS X (11.7.10):
```
WakeOnLAN.c: In function 'main':
WakeOnLAN.c:158:63: error: 'SO_BINDTODEVICE' undeclared (first use in this function)
  158 |                         if (setsockopt(udpSocket, SOL_SOCKET, SO_BINDTODEVICE, (void *)&ifr, sizeof(ifr)) < 0) {
      |                                                               ^~~~~~~~~~~~~~~
WakeOnLAN.c:158:63: note: each undeclared identifier is reported only once for each function it appears in
make: *** [WakeOnLAN] Error 1
```

Luca